### PR TITLE
TP-26139 Label Resolution Option: Update API docs

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1971,6 +1971,9 @@ PDF format or in PNG. In the former case, there is one PDF returned
 with multiple labels concatenated in a single document (one label per
 page). In the latter case, we cannot concatenate PNG files together,
 so a ZIP file is returned instead that contains all files.
+ZPL labels can be configured as 230 or 300 DPI resolution.
+It's also possible to specify the required label resolution per request.
+To enable this feature, contact Scurri support.
 
 About the customs invoice documents, Scurri will return the documents
 the carrier requires, only if the carrier does require them for the


### PR DESCRIPTION
Label Resolution Option: Update API docs
https://scurri.tpondemand.com/entity/26139-label-resolution-option-update-api-docs

As Ops, I would like the API docs to be updated with the new label resolution option so that customers are aware that we have this feature available. 

**Acceptance Criteria**
- In the API docs available online, add the following updates: 
Next text to be added underneath the paragraph:
'The resulting documents are base64-encoded and they can be either in PDF format or in PNG. In the former case, there is one PDF returned with multiple labels concatenated in a single document (one label per page). In the latter case, we cannot concatenate PNG files together, so a ZIP file is returned instead that contains all files.' 
- New text 'Labels can be configured as 230 or 300 DPI resolution. It's also possible to specify the required label resolution per request. To enable this feature, contact Scurri support. 

New and potential customers are aware of the option to specify the label resolution per request. 