### PR TITLE
TP-31240 Posting consignment data - updating docs regarding options

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1206,7 +1206,7 @@ for the payload of this request.
                 "order_number": "8384832",
                 "options": {
                   "package_type": "Parcel",
-                  "signed": "yes"
+                  "signed": "Yes"
                 }
               }
             ]
@@ -1844,7 +1844,7 @@ values, when using this API call.
               "order_number": "8384832",
               "options": {
                 "package_type": "Bag",
-                "signed": "no"
+                "signed": "No"
               }
             }
 


### PR DESCRIPTION
This PR is a result of an OpsTeam support query.
https://scurri.tpondemand.com/entity/30637-error-when-trying-to-resubmit-shipment
Our documentation is inconsistent.
We inform the user they can post consignments in this format
```
    },
    "order_number": "8384832",
    "options": {
      "package_type": "Parcel",
      "signed": "yes"
    }
  }
```
and this results in creating a valid entry, but the enhancement values are ["Yes", "No"] and it may result in problems with printing the consignment using UI
( more details in the related card)
We need to fix this to:
```
    },
    "order_number": "8384832",
    "options": {
      "package_type": "Parcel",
      "signed": "Yes"
    }
  }
```
so the users are aware this value should be in uppercase, also it would be beneficial to inform them, that if the do not post "signed" value, it will default to "No". so the value can be omited